### PR TITLE
Use Google Mobile Ads package from Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     dependencies: [
         .package(
             name: "GoogleMobileAds",
-            url: "https://github.com/quanghits/GoogleMobileAds.git",
-            .upToNextMajor(from: "8.13.0")
+            url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
+            .upToNextMajor(from: "11.5.0")
         ),
         .package(
             name: "KeyWindow",

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ let package = Package(
     packages: [
         .package(
             name: "AdMobUI",
-            url: "https://github.com/Spacerat/AdMobUI.git",
-            .upToNextMajor(from: "1.1.0")
+            url: "https://github.com/briannadoubt/AdMobUI.git",
+            .upToNextMajor(from: "1.0.1")
         )
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**NOTE:** This fork of AdMobUI switches to using the latest version of GoogleMobileAds, which is now provided by Google for Swift Package Manager. 
+
 # AdMobUI
 
 A simple AdMob ads wrapper for SwiftUI
@@ -55,8 +57,6 @@ struct ContentView: View {
 ## Installation
 
 AdMobUI only support iOS since the `GoogleMobileAdsSDK` doesn't support any other operating system.
-
-AdMobUI also pulls `GoogleMobileAdsSDK` through an unofficial swift package in order to avoid using `cocoapods`. There are known issues when archiving your product. More info here: https://github.com/quanghits/GoogleMobileAds
 
 ### Discussion
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ let package = Package(
     name: "MySwiftPackage",
     packages: [
         .package(
-            name: "KeyWindow",
-            url: "https://github.com/briannadoubt/KeyWindow.git",
-            .upToNextMajor(from: "0.1.0")
+            name: "AdMobUI",
+            url: "https://github.com/Spacerat/AdMobUI.git",
+            .upToNextMajor(from: "1.1.0")
         )
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-**NOTE:** This fork of AdMobUI switches to using the latest version of GoogleMobileAds, which is now provided by Google for Swift Package Manager. 
-
 # AdMobUI
 
 A simple AdMob ads wrapper for SwiftUI

--- a/Sources/AdMobUI/AnchoredAd.swift
+++ b/Sources/AdMobUI/AnchoredAd.swift
@@ -30,6 +30,12 @@ public struct AnchoredAd: View {
         self.width = size.width
     }
     
+    public init(ad: Advertisement, height: CGFloat = 320, width: CGFloat = 320) {
+        self.ad = ad
+        self.height = height
+        self.width = width
+    }
+    
     public var body: some View {
         Group {
             if showingAds {

--- a/Sources/AdMobUI/InlineAd.swift
+++ b/Sources/AdMobUI/InlineAd.swift
@@ -122,10 +122,10 @@ extension InlineAdViewController: GADBannerViewDelegate {
     public func bannerViewDidReceiveAd(_ bannerView: GADBannerView) {
         if
             let responseInfo = bannerView.responseInfo,
-            let responseIdentifier = responseInfo.responseIdentifier,
-            let adNetworkClassName = responseInfo.adNetworkClassName
+            let responseIdentifier = responseInfo.responseIdentifier
         {
-            print("adViewDidReceiveAd from network: \(adNetworkClassName), response Id='\(responseIdentifier)'")
+            let adNetworkClassName = responseInfo.adNetworkInfoArray.map(\.adNetworkClassName).joined(separator: ", ")
+            print("adViewDidReceiveAd from network: \(adNetworkClassName). response Id='\(responseIdentifier)'")
         }
     }
     


### PR DESCRIPTION
Hi @briannadoubt 

I came across your AdMobUI package and was very happy to find a Swift wrapper for AdMob which just works. 🥳 

Since you created your library, Google updated their GoogleMobileAds repository for the latest version of SwiftPackageManger!

I tested it and it seems to work great - the only change I had to make for the update was to use `adNetworkInfoArray`.